### PR TITLE
Fixed percentage lower than 0 not showing 0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>net.aboodyy.progressexpansion</groupId>
     <artifactId>progress-expansion</artifactId>
     <name>Expansion-Progress</name>
-    <version>2.1</version>
+    <version>2.2</version>
 
     <repositories>
         <repository>

--- a/src/main/java/net/aboodyy/progressexpansion/ProgressExpansion.java
+++ b/src/main/java/net/aboodyy/progressexpansion/ProgressExpansion.java
@@ -46,7 +46,7 @@ public class ProgressExpansion extends PlaceholderExpansion implements Configura
 
     @Override
     public String getVersion() {
-        return "2.1";
+        return "2.2";
     }
 
     @Override
@@ -106,7 +106,7 @@ public class ProgressExpansion extends PlaceholderExpansion implements Configura
             if (placeholder >= max) return "100";
             if (max == 0) return "0";
 
-            StringBuilder f = new StringBuilder("#");
+            StringBuilder f = new StringBuilder("0");
             if (decimal > 0) {
                 f.append(".");
                 for (int i = 0; i < decimal; i++) {


### PR DESCRIPTION
Percentages lower than 0 (`0.25` for example) were not showing `0`, just `.25`